### PR TITLE
include the volume name is the return value of _path()

### DIFF
--- a/src/Driver.php
+++ b/src/Driver.php
@@ -515,7 +515,7 @@ class Driver extends elFinderVolumeDriver {
      **/
     protected function _path($path)
     {
-        return $path;
+        return $this->rootName.$this->separator.$path;
     }
 
     /**


### PR DESCRIPTION
It is desirable to include the volume name is the return value of _path().

Thanks!