### PR TITLE
fix "Class 'League\Glide\Http\UrlBuilderFactory' not found" 

### DIFF
--- a/src/Driver.php
+++ b/src/Driver.php
@@ -6,7 +6,7 @@ use elFinderVolumeDriver;
 use Intervention\Image\ImageManager;
 use League\Flysystem\Util;
 use League\Flysystem\FilesystemInterface;
-use League\Glide\Http\UrlBuilderFactory;
+use League\Glide\Urls\UrlBuilderFactory;
 use Barryvdh\elFinderFlysystemDriver\Plugin\GetUrl;
 
 /**


### PR DESCRIPTION
make it works with glide ^1.0

references to #18