### PR TITLE
Cached Adapter supports with \Hypweb\Flysystem\Cached\Extra\Hasdir

### DIFF
--- a/src/Plugin/HasDir.php
+++ b/src/Plugin/HasDir.php
@@ -82,7 +82,10 @@ class HasDir extends AbstractPlugin
      */
     protected function getFromMethod($path)
     {
-        $res = $this->adapter->hasDir($path);
+        $res = $this->filesystem->getMetadata($path);
+        if (!$res || !isset($res['hasdir'])) {
+            $res = $this->adapter->hasDir($path);
+        }
         if (is_array($res)) {
             return isset($res['hasdir'])? $res['hasdir'] : true;
         } else {


### PR DESCRIPTION
**Cache works completely**

- https://github.com/nao-pon/flysystem-cached-extra

```php
class myCachedStrageAdapter extends
\League\Flysystem\Cached\Storage\Adapter
{
    use \Hypweb\Flysystem\Cached\Extra\Hasdir;
}

$cache = new myCachedStrageAdapter(
    new \League\Flysystem\Adapter\Local('./flycache')
    , 'gdcache', 300
);

$client = new \Google_Client();
$client->setClientId('ClientId');
$client->setClientSecret('ClientSecret');
$client->refreshToken('RefreshToken');
$service = new \Google_Service_Drive($client);

$googleDrive = new
\Hypweb\Flysystem\GoogleDrive\GoogleDriveAdapter($service,
'root', [ 'useHasDir' => true ]);

$root[] = [
    'driver' => 'Flysystem',
    'filesystem' => new Filesystem(
        new \League\Flysystem\Cached\CachedAdapter(
            $googleDrive,
            $cache
        )
    ),
    'fscache' => $cache
];
```