### PR TITLE
fix detecting of `$stat['name']` by `$meta['filename']`

### DIFF
--- a/src/Driver.php
+++ b/src/Driver.php
@@ -274,9 +274,12 @@ class Driver extends elFinderVolumeDriver {
             return array();
         }
 
-        // Set item filename to `name` if exists
-        if (isset($meta['filename'])) {
+        // Set item filename.extension to `name` if exists
+        if (isset($meta['filename']) && isset($meta['extension'])) {
             $stat['name'] = $meta['filename'];
+            if ($meta['extension'] !== '') {
+                $stat['name'] .= '.' . $meta['extension'];
+            }
         }
 
         // Get timestamp/size


### PR DESCRIPTION
"$meta['filename']" does not include a file extension in many cases.