### PR TITLE
enable option 'checkSubfolders' when adapter has `hasDir`

### DIFF
--- a/src/Driver.php
+++ b/src/Driver.php
@@ -125,6 +125,10 @@ class Driver extends elFinderVolumeDriver {
         $this->fs->addPlugin(new GetUrl());
         $this->fs->addPlugin(new HasDir());
 
+        if ($this->fs->hasDir()) {
+            $this->options['checkSubfolders'] = true;
+        }
+
         $this->options['icon'] = $this->options['icon'] ?: $this->getIcon();
         $this->root = $this->options['path'];
 


### PR DESCRIPTION
Added auto detecting of option 'checkSubfolders'.