### PR TITLE
Get mimetype when not in metadata

### DIFF
--- a/src/Driver.php
+++ b/src/Driver.php
@@ -302,7 +302,11 @@ class Driver extends elFinderVolumeDriver
 
         // Check if file, if so, check mimetype when available
         if ($meta['type'] == 'file') {
-            $stat['mime'] = isset($meta['mimetype']) ? $meta['mimetype'] : null;
+            if(isset($meta['mimetype'])) {
+                $stat['mime'] = $meta['mimetype'];
+            } else {
+                $stat['mime'] = $this->fs->getMimetype($path);
+            }
 
             $imgMimes = ['image/jpeg', 'image/png', 'image/gif'];
             if ($this->urlBuilder && in_array($stat['mime'], $imgMimes)) {


### PR DESCRIPTION
Get the mimetype from the filesystem of the file when it is not supplied in the metadata. This fixes the default behaviour in the local driver (metadata does not contain mime), and glide support as well.