### PR TITLE
Added the 'cache' option to the example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,8 @@ You can use the driver by setting the connector config to Flysystem.
             'driver' => 'Flysystem', 
             'path' => 'images',
             'URL' => '/images', 
-            'filesystem' => new Filesystem(new LocalAdapter('/path/to/public_html'))
+            'filesystem' => new Filesystem(new LocalAdapter('/path/to/public_html')),
+            'cache' => 'session' // 'session' or 'memory'. Defaults to 'session'. This option is also available for other adapters.
         ],
         [
             'driver' => 'Flysystem',


### PR DESCRIPTION
It was annoying to search the source of cache since I didn't know if it was caching in flysystem, elfinder or this driver. At least this way we can see it easily.