### PR TITLE
Fix type hint

### DIFF
--- a/src/Driver.php
+++ b/src/Driver.php
@@ -36,7 +36,7 @@ class Driver extends elFinderVolumeDriver
     /** @var CacheInterface $fs */
     protected $fscache;
 
-    /** @var UrlBuilderFactory $urlBuilder */
+    /** @var UrlBuilder $urlBuilder */
     protected $urlBuilder = null;
 
     /** @var ImageManager $imageManager */
@@ -344,7 +344,7 @@ class Driver extends elFinderVolumeDriver
         $filter = function ($item) {
             return $item['type'] == 'dir';
         };
-        
+
         $dirs = array_filter($contents, $filter);
         return !empty($dirs);
     }


### PR DESCRIPTION
This is a fairly trivial change: `UrlBuilderFactory::create()` does not return an object of class UrlBuilderFactory, in fact it returns one of UrlBuilder.

Comment change only but it helps with type hinting in phpStorm.
