### PR TITLE
Filesystem cache wrapping now accepts original filesystem config

### DIFF
--- a/src/Driver.php
+++ b/src/Driver.php
@@ -147,7 +147,7 @@ class Driver extends elFinderVolumeDriver
 
                 if ($this->fscache) {
                     $adapter = new CachedAdapter($adapter, $this->fscache);
-                    $this->fs = new Filesystem($adapter);
+                    $this->fs = new Filesystem($adapter, $this->fs->getConfig());
                 }
             }
         }


### PR DESCRIPTION
closes #73 

Considering following filesystem configuration:
```php
// ... configuration
$s3Adapter = new AwsS3Adapter($s3Client, $bucketName);

return new Filesystem($s3Adapter, [
    'visibility' => AdapterInterface::VISIBILITY_PUBLIC,
]); 
```

When filesystem is mounted, it's wrapped into `CachedAdapter` (because `AwsS3Adapter` is not the descendant of `League\Flysystem\Cached\CachedAdapter`) in `Driver::init()` method.

In this method, property `$fs` is replaced: `$this->fs = new Filesystem($adapter);`.
But this effectively drops the "visibility" configuration.

Proposed change add original filesystem configuration into newly created filesystem.