### PR TITLE
Intervention image v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "intervention/image": "^3.1",
+        "intervention/image": "^3.1|^4",
         "league/flysystem": "^3",
         "studio-42/elfinder": "^2.1.62"
     },

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -3,6 +3,7 @@
 namespace Barryvdh\elFinderFlysystemDriver;
 
 use elFinderVolumeDriver;
+use Intervention\Image\Drivers\Gd\Driver as GdDriver;
 use Intervention\Image\Encoders\AutoEncoder;
 use Intervention\Image\Encoders\JpegEncoder;
 use Intervention\Image\ImageManager;
@@ -125,7 +126,7 @@ class Driver extends elFinderVolumeDriver
         if ($this->options['imageManager']) {
             $this->imageManager = $this->options['imageManager'];
         } else {
-            $this->imageManager = ImageManager::gd();
+            $this->imageManager = new ImageManager(new GdDriver());
         }
 
         // enable command archive
@@ -756,7 +757,9 @@ class Driver extends elFinderVolumeDriver
             return $this->setError(elFinder::ERROR_UNSUPPORT_TYPE);
         }
 
-        if (!$image = $this->imageManager->read($this->_getContents($path))) {
+        // See https://image.intervention.io/v4/getting-started/upgrade
+        $decodeMethod = method_exists($this->imageManager, 'decode') ? 'decode' : 'read';
+        if (!$image = $this->imageManager->{$decodeMethod}($this->_getContents($path))) {
             return false;
         }
 


### PR DESCRIPTION
This is part of a series of PRs I will contribute, achieving the following things, which are not directly related and thus will be submitted individually. The full set consists of PRs:
- #98
- #99 
- #100
- #101 
- #102
- #103
- #104

It adds compatibility with intervention/image v4, where changes in other PRs have been added to test that this is indeed functionally correct.

It is based on top of #102 to hopefully prevent merge conflicts.

The full set of changes should result in:
- an up-to-date set of CI testing, with modern package & PHP versions
- compatibility with intervention/image v4; see also https://github.com/Intervention/image/releases/tag/4.0.0 and https://image.intervention.io/v4/getting-started/upgrade
- some (bug)fixes and general code cleanup

An overview of all combined changes was tested with: https://github.com/jnoordsij/elfinder-flysystem-driver/pull/1.