### PR TITLE
Update PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "league/flysystem-memory": "^3",
         "phpstan/phpstan": "^1.4",
-        "phpunit/phpunit": "^9",
+        "phpunit/phpunit": "^10|^13",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^8.1",
         "studio-42/elfinder": "^2.1.62",
         "league/flysystem": "^3",
-        "intervention/image": "^3"
+        "intervention/image": "^3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9",

--- a/composer.json
+++ b/composer.json
@@ -11,15 +11,15 @@
     ],
     "require": {
         "php": "^8.1",
-        "studio-42/elfinder": "^2.1.62",
+        "intervention/image": "^3.1",
         "league/flysystem": "^3",
-        "intervention/image": "^3.1"
+        "studio-42/elfinder": "^2.1.62"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9",
-        "squizlabs/php_codesniffer": "^3.5",
+        "league/flysystem-memory": "^3",
         "phpstan/phpstan": "^1.4",
-        "league/flysystem-memory": "^3"
+        "phpunit/phpunit": "^9",
+        "squizlabs/php_codesniffer": "^3.5"
     },
     "suggest": {
         "league/glide": "1.x to display images through Glide"

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -4,6 +4,7 @@ namespace Barryvdh\elFinderFlysystemDriver;
 
 use elFinderVolumeDriver;
 use Intervention\Image\Encoders\AutoEncoder;
+use Intervention\Image\Encoders\JpegEncoder;
 use Intervention\Image\ImageManager;
 use League\Flysystem\Cached\CachedAdapter;
 use League\Flysystem\Cached\CacheInterface;
@@ -729,7 +730,7 @@ class Driver extends elFinderVolumeDriver
      * @param  string $mode action how to mainpulate image
      * @param  string $bg background color
      * @param  int $degree rotete degree
-     * @param  int $jpgQuality JEPG quality (1-100)
+     * @param  int $jpgQuality JPEG quality (1-100)
      * @return array|false
      * @author Dmitry (dio) Levashov
      * @author Alexey Sukhotin
@@ -782,9 +783,9 @@ class Driver extends elFinderVolumeDriver
         }
 
         if ($jpgQuality) {
-            $result = $image->encode(new AutoEncoder(quality: $jpgQuality))->toString();
+            $result = $image->encode(new JpegEncoder(quality: $jpgQuality))->toString();
         } else {
-            $result = $image->encode()->toString();
+            $result = $image->encode(new AutoEncoder())->toString();
         }
         if ($result && $this->_filePutContents($path, $result)) {
             $this->rmTmb($file);


### PR DESCRIPTION
This is part of a series of PRs I will contribute, achieving the following things, which are not directly related and thus will be submitted individually. The full set consists of PRs:
- #98
- #99 
- #100
- #101 
- #102
- #103
- #104

This PR updates to PHPUnit version to v10 minimum (highest version compatible with PHP 8.1) and also allows v13 (latest version).

It is based on top of #102 to hopefully prevent merge conflicts.
It shares a commit with #103 to hopefully prevent merge conflicts.

The full set of changes should result in:
- an up-to-date set of CI testing, with modern package & PHP versions
- compatibility with intervention/image v4; see also https://github.com/Intervention/image/releases/tag/4.0.0 and https://image.intervention.io/v4/getting-started/upgrade
- some (bug)fixes and general code cleanup

An overview of all combined changes was tested with: https://github.com/jnoordsij/elfinder-flysystem-driver/pull/1.